### PR TITLE
Add common render_command_string() for command rendering in layers

### DIFF
--- a/vtds_base/__init__.py
+++ b/vtds_base/__init__.py
@@ -47,7 +47,8 @@ from .base_config import (
 
 from .template_operations import (
     render_template_file,
-    render_templated_tree
+    render_templated_tree,
+    render_command_string
 )
 
 from .stack import (

--- a/vtds_base/template_operations.py
+++ b/vtds_base/template_operations.py
@@ -81,3 +81,21 @@ def render_templated_tree(patterns, data, build_dir):
         paths = glob("%s/**/%s" % (build_dir, pattern), recursive=True)
         for path in paths:
             render_template_file(path, data)
+
+
+def render_command_string(cmd, jinja_values):
+    """Render a command string (not a command list) as a Jinja
+    template with substitutions from the supplied jinja_values
+    dictionary.
+
+    """
+    try:
+        template = Template(cmd)
+        return template.render(**jinja_values)
+    except TemplateError as err:
+        raise ContextualError(
+            "error using Jinja to render command line '%s' - %s" % (
+                cmd,
+                str(err)
+            )
+        ) from err


### PR DESCRIPTION
## Summary and Scope

Pull the command string rendering out of the layers where it is replicated and into the base library.