### PR TITLE
Vsha 638

### DIFF
--- a/vtds_base/layers/cluster/cluster.py
+++ b/vtds_base/layers/cluster/cluster.py
@@ -49,18 +49,3 @@ class ClusterAPI(LayerAPI, metaclass=ABCMeta):
         available VirtualNetworks.
 
         """
-
-    @abstractmethod
-    def get_node_venv_path(self):
-        """Return the file system path to the root of the shared blade
-        virtual environment created and managed by the Platform layer.
-
-        """
-
-    @abstractmethod
-    def get_node_python_executable(self):
-        """Return the file system path to the executable python
-        interpreter within the shared blade virtual environment
-        created and managed by the Platform layer.
-
-        """

--- a/vtds_base/layers/cluster/cluster.py
+++ b/vtds_base/layers/cluster/cluster.py
@@ -49,3 +49,18 @@ class ClusterAPI(LayerAPI, metaclass=ABCMeta):
         available VirtualNetworks.
 
         """
+
+    @abstractmethod
+    def get_node_venv_path(self):
+        """Return the file system path to the root of the shared blade
+        virtual environment created and managed by the Platform layer.
+
+        """
+
+    @abstractmethod
+    def get_node_python_executable(self):
+        """Return the file system path to the executable python
+        interpreter within the shared blade virtual environment
+        created and managed by the Platform layer.
+
+        """

--- a/vtds_base/layers/platform/platform.py
+++ b/vtds_base/layers/platform/platform.py
@@ -25,7 +25,10 @@ access to the Platform API and prevents them from seeing the private
 implementation of the API.
 
 """
-from abc import ABCMeta
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
 from ..layerapi import LayerAPI
 
 
@@ -33,3 +36,17 @@ class PlatformAPI(LayerAPI, metaclass=ABCMeta):
     """ Presents the Platform API to callers.
 
     """
+    @abstractmethod
+    def get_blade_venv_path(self):
+        """Return the file system path to the root of the shared blade
+        virtual environment created and managed by the Platform layer.
+
+        """
+
+    @abstractmethod
+    def get_blade_python_executable(self):
+        """Return the file system path to the executable python
+        interpreter within the shared blade virtual environment
+        created and managed by the Platform layer.
+
+        """


### PR DESCRIPTION
## Summary and Scope

This PR removes the cluster layer API methods for a node level share Python virtual environment. It turns out that the cluster layer is not the place to create a node level virtual environment because the cluster doesn't manage node resources, it simply sets up networks and nodes and prepares them for the Application layer to manage their resources. That make creating any virtual environment or installing any modules or packages on the Virtual Nodes an Application specific activity with no need for lower layer support.