### PR TITLE
Remove Pythn venv API methods from cluster (not where they belong)

### DIFF
--- a/vtds_base/layers/cluster/cluster.py
+++ b/vtds_base/layers/cluster/cluster.py
@@ -49,18 +49,3 @@ class ClusterAPI(LayerAPI, metaclass=ABCMeta):
         available VirtualNetworks.
 
         """
-
-    @abstractmethod
-    def get_node_venv_path(self):
-        """Return the file system path to the root of the shared blade
-        virtual environment created and managed by the Platform layer.
-
-        """
-
-    @abstractmethod
-    def get_node_python_executable(self):
-        """Return the file system path to the executable python
-        interpreter within the shared blade virtual environment
-        created and managed by the Platform layer.
-
-        """


### PR DESCRIPTION
## Summary and Scope

[Trying again -- github was in a weird state and didn't do this right in the previous PR]

This PR removes the cluster layer API methods for a node level share Python virtual environment. It turns out that the cluster layer is not the place to create a node level virtual environment because the cluster doesn't manage node resources, it simply sets up networks and nodes and prepares them for the Application layer to manage their resources. That make creating any virtual environment or installing any modules or packages on the Virtual Nodes an Application specific activity with no need for lower layer support.
