### PR TITLE
Add separate node naming versus host naming to cluster layer API

### DIFF
--- a/vtds_base/layers/cluster/api_objects.py
+++ b/vtds_base/layers/cluster/api_objects.py
@@ -50,6 +50,16 @@ class VirtualNodesBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def node_node_name(self, node_class, instance):
+        """Get the node name (used for contextually naming the
+        implementation of a Virtual Node) of a given Virtual Node
+        class instance (i.e. Virtual Node). This will also be the core
+        hostname (minus the network name) of the node if there is no
+        host naming specified in the configuration.
+
+        """
+
+    @abstractmethod
     def network_names(self, node_class):
         """Return the list of Network Names of the Networks connected
         to the specified class of Virtual Node.


### PR DESCRIPTION
## Summary and Scope

Add separate node naming versus host naming to the cluster API. This will support cases where we want to use a different class of names, for example xnames, for naming the implementation of Virtual Nodes contextually (for example within libvirt for use by Sushy-Tools). If separate host naming and node naming are specified in the configuration the host naming will be used for network host names and the node naming will be used for contextual Virtual Node naming. If there is no host naming specified, then the node name will be used for both.
