### PR TITLE
Add application_metadata() methods for configuration API objects

### DIFF
--- a/vtds_base/layers/cluster/api_objects.py
+++ b/vtds_base/layers/cluster/api_objects.py
@@ -43,6 +43,13 @@ class VirtualNodesBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def application_metadata(self, node_class):
+        """Get the application metadata for a named node class from
+        its config.
+
+        """
+
+    @abstractmethod
     def node_count(self, node_class):
         """Get the number of Virtual Node instances of the specified
         class.
@@ -201,6 +208,13 @@ class VirtualNetworksBase(metaclass=ABCMeta):
     @abstractmethod
     def network_names(self):
         """Get a list of network names
+
+        """
+
+    @abstractmethod
+    def application_metadata(self, node_class):
+        """Get the application metadata for a named virtual network
+        from its config.
 
         """
 

--- a/vtds_base/layers/provider/api_objects.py
+++ b/vtds_base/layers/provider/api_objects.py
@@ -42,6 +42,13 @@ class VirtualBladesBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def application_metadata(self, blade_class):
+        """Get the application metadata for a named blade class from
+        its config.
+
+        """
+
+    @abstractmethod
     def blade_count(self, blade_class):
         """Get the number of Virtual Blade instances of the specified
         class.
@@ -165,6 +172,13 @@ class BladeInterconnectsBase(metaclass=ABCMeta):
     @abstractmethod
     def interconnect_names(self):
         """Get a list of blade interconnects by name
+
+        """
+
+    @abstractmethod
+    def application_metadata(self, interconnect_name):
+        """Get the application metadata for a named interconnect from
+        its config.
 
         """
 
@@ -526,5 +540,12 @@ class SecretsBase(metaclass=ABCMeta):
     def read(self, name):
         """Read the value (string) stored in a named secret. If no
         value is present, return None.
+
+        """
+
+    @abstractmethod
+    def application_metadata(self, name):
+        """Get the application metadata for a named secret from its
+        config.
 
         """


### PR DESCRIPTION
## Summary and Scope

Add Application Metadata retrieval methods to configuration API Objects in the Provider and Cluster layers. Application Metadata allows a developer of a new application to attach application specific data to API objects within a configuration set so that the application can understand the API objects better. It is only intended to be read or understood by the Application layer of the application for which a given configuration set was written. It is never read by any other layer.
