### PR TITLE
Fix method protoype for virtual network application_metadata()

### DIFF
--- a/vtds_base/layers/cluster/api_objects.py
+++ b/vtds_base/layers/cluster/api_objects.py
@@ -212,7 +212,7 @@ class VirtualNetworksBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def application_metadata(self, node_class):
+    def application_metadata(self, network_name):
         """Get the application metadata for a named virtual network
         from its config.
 


### PR DESCRIPTION
## Summary and Scope

Fix the virtual function prototype signature for the Virtual Network application_metadata() function to take a 'network_name' instead of a 'node_class' name.
