### PR TITLE
Add site config API object and getter

### DIFF
--- a/vtds_base/layers/provider/api_objects.py
+++ b/vtds_base/layers/provider/api_objects.py
@@ -30,6 +30,59 @@ from abc import (
 )
 
 
+class SiteConfigBase(metaclass=ABCMeta):
+    """A class implementing public access to site configuration
+    settings.
+
+    """
+
+    @abstractmethod
+    def system_name(self):
+        """Get the system name used to create the cluster on the
+        provider. Returns a string representing the system name.
+
+        """
+
+    @abstractmethod
+    def site_ntp_servers(self, address_family='AF_INET'):
+        """Get the hostname / address of the NTP server offered by the
+        provider or site in the specified address family. The
+        'address_family' parameter is a string specifies the address
+        family of the address to be returned, with a default value of
+        'AF_INET'. Returns a list of dictionaries containing the
+        following fields:
+
+        - 'address_family' - the requested address family as passed in
+        - 'hostname' - the host name of the NTP server if known, None if not
+        - 'address' - the address within the address family of the NTP
+          server if known, None if not
+
+        Returns an empty list if the specified 'address_family' is not
+        supported by the provider or not configured in the Provider
+        configuration.
+
+        """
+
+    @abstractmethod
+    def site_dns_servers(self, address_family='AF_INET'):
+        """Get the address of the DNS server offered by the provider
+        or site on the specified address family. The address_family'
+        parameter is a string specifies the address family of the
+        address to be returned, with a default value of
+        'AF_INET'. Returns a list of dictionarie containing the
+        following fields:
+
+        - 'address_family' - the requested address family as passed in
+        - 'address' - the address within the address family of the NTP
+          server if known, None if not
+
+        Returns an empty list if the specified 'address_family' is not
+        supported by the provider or not configured in the Provider
+        configuration.
+
+        """
+
+
 class VirtualBladesBase(metaclass=ABCMeta):
     """A class implementing public access to Virtual Blades and their
     operations.

--- a/vtds_base/layers/provider/provider.py
+++ b/vtds_base/layers/provider/provider.py
@@ -56,3 +56,9 @@ class ProviderAPI(LayerAPI, metaclass=ABCMeta):
         available secrets.
 
         """
+
+    @abstractmethod
+    def get_site_config(self):
+        """Retrieve the SiteConfig API object from the Provider.
+
+        """


### PR DESCRIPTION
## Summary and Scope

Add a SiteConfig API object to the Provider API to isolate Provider or Site specific configuration like DNS or NTP servers in the provider layer since that layer is closest to the site and often these site parameters are actually native o the provider itself.